### PR TITLE
feat(master): allow variadic on generic type

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -191,7 +191,7 @@ module.exports = grammar(lua, {
       $.type,
     )),
 
-    generic_type: $ => generic_type: $ => seq($.identifier, '<', commaSep(seq($.type, optional('...'))), '>'),
+    generic_type: $ => $ => seq($.identifier, '<', commaSep(seq($.type, optional('...'))), '>'),
 
     object_type: $ => seq(
       '{',

--- a/grammar.js
+++ b/grammar.js
@@ -191,7 +191,7 @@ module.exports = grammar(lua, {
       $.type,
     )),
 
-    generic_type: $ => seq($.identifier, '<', commaSep($.type), '>'),
+    generic_type: $ => generic_type: $ => seq($.identifier, '<', commaSep(seq($.type, optional('...'))), '>'),
 
     object_type: $ => seq(
       '{',

--- a/grammar.js
+++ b/grammar.js
@@ -191,7 +191,7 @@ module.exports = grammar(lua, {
       $.type,
     )),
 
-    generic_type: $ => $ => seq($.identifier, '<', commaSep(seq($.type, optional('...'))), '>'),
+    generic_type: $ => seq($.identifier, '<', commaSep(seq($.type, optional("..."))), '>'), 
 
     object_type: $ => seq(
       '{',


### PR DESCRIPTION
Add support for variadic generic type.

Before, the following examples would not highlight properly:

```luau
type A<T...> = B<T...>
```